### PR TITLE
enable ForwardAgent ssh option

### DIFF
--- a/lib/cap_vagrant/templates/stage.rb.erb
+++ b/lib/cap_vagrant/templates/stage.rb.erb
@@ -6,3 +6,10 @@ default_environment["RAILS_ENV"] = "#{rails_env}"
 set :user, "<%= vars['user'] %>"
 ssh_options[:keys] = ['<%= vars['keys'] %>']
 ssh_options[:port] = <%= vars['port'] %>
+
+# that doesn't work for me for unknown reason
+# ssh_options[:forward_agent] = true
+# (as well as 'ForwardAgent yes' in .ssh/config
+
+# but this works as expected
+set :ssh_options, {:forward_agent => true}


### PR DESCRIPTION
enable :forward_agent ssh option for password-less login to vagrant machine
